### PR TITLE
Added home command to teleport you to your bed location.

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -11,3 +11,6 @@ commands:
   help:
     description: Recieve help information about Skrillcraft
     usage: /<command>
+  home:
+    description: Teleport to your bed.
+    usage: /<command>

--- a/src/xyz/skrillcraft/plugin/Main.java
+++ b/src/xyz/skrillcraft/plugin/Main.java
@@ -1,6 +1,7 @@
 package xyz.skrillcraft.plugin;
 
 import xyz.skrillcraft.plugin.commands.HelpCommand;
+import xyz.skrillcraft.plugin.commands.HomeCommand;
 import xyz.skrillcraft.plugin.commands.SpawnCommand;
 import xyz.skrillcraft.plugin.events.OnPlayerChat;
 import xyz.skrillcraft.plugin.events.OnPlayerJoin;
@@ -27,6 +28,7 @@ public class Main extends JavaPlugin {
 
         getCommand("spawn").setExecutor(new SpawnCommand());
         getCommand("help").setExecutor(new HelpCommand());
+        getCommand("home").setExecutor(new HomeCommand());
     }
 
     @Override

--- a/src/xyz/skrillcraft/plugin/commands/HomeCommand.java
+++ b/src/xyz/skrillcraft/plugin/commands/HomeCommand.java
@@ -1,0 +1,25 @@
+package xyz.skrillcraft.plugin.commands;
+
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class HomeCommand implements CommandExecutor {
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (sender instanceof Player) {
+            Player player = (Player) sender;
+
+            Location home = player.getBedSpawnLocation();
+
+            if (home != null) {
+                player.teleport(home);
+            } else {
+                player.sendMessage("§fYour home bed was missing or obstructed");
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
When a user types `/home` they are teleported to their bed's location. If they have not set a bed they will get the generic "Your home bed was missing or obstructed" message in chat.